### PR TITLE
socket, generate code, url in shared/stateInit.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ testem.log
 /e2e/*.js
 /e2e/*.map
 
-#System Files
+# System Files
 .DS_Store
 Thumbs.db
+
+# Vim temporary files
+*.swp

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "^2.3.1",
     "@angular/router": "^3.3.1",
     "core-js": "^2.4.1",
+    "ngx-socket-io": "^1.0.6",
     "rxjs": "^5.0.1",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.7.2"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,26 +1,40 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { NgModule } from '@angular/core';
+import { SocketIoModule, SocketIoConfig } from 'ngx-socket-io';
 
 import { AppComponent } from './app.component';
-import { ProductComponent } from './product/product.component';
 import { PhotoMgrComponent } from './photo-mgr/photo-mgr.component';
+import { ProductComponent } from './product/product.component';
+import { SyncComponent } from './sync/sync.component';
 import { WelcomeComponent } from './welcome/welcome.component';
+
+import { SocketService } from './socket.service';
+import { stateInit } from './shared/stateInit';
+
+const config: SocketIoConfig = {
+    url: stateInit.socket_url,
+    options: {}
+};
 
 @NgModule({
   declarations: [
     AppComponent,
     ProductComponent,
     PhotoMgrComponent,
-    WelcomeComponent
+    WelcomeComponent,
+    SyncComponent
   ],
   imports: [
     BrowserModule,
     FormsModule,
-    HttpModule
+    HttpModule,
+    SocketIoModule.forRoot(config),
   ],
-  providers: [],
+  providers: [
+    SocketService, 
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/shared/stateInit.ts
+++ b/src/app/shared/stateInit.ts
@@ -2,5 +2,6 @@ export const stateInit = {
   customer_present: false,
   product_available: false,
   paired_to_phone: false,
-  photos:[]
+  photos:[],
+  socket_url: 'ec2-54-221-218-6.compute-1.amazonaws.com:4000',
   }

--- a/src/app/socket.service.ts
+++ b/src/app/socket.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Socket } from 'ngx-socket-io';
+
+@Injectable()
+export class SocketService {
+
+  constructor(private socket: Socket) { }
+
+  getCode() {
+    return String(Math.floor(1000 + Math.random() * 9000));
+  }
+
+  sendMirrorCode(code) {
+    this.socket.emit('mirror', code);
+  }
+
+  getProblems() {
+    let observable = new Observable(observer => {
+      this.socket.on('problem', (data) => {
+        observer.next(data);
+      });
+
+      return () => {
+        this.socket.disconnect();
+      };
+    })
+
+    return observable;
+  }
+
+  getConnect() {
+    let observable = new Observable(observer => {
+      this.socket.on('phoneConnected', (data) => {
+        observer.next(data);
+      });
+
+      return () => {
+        this.socket.disconnect();
+      };
+    })
+
+    return observable;
+  }
+
+}

--- a/src/app/sync/sync.component.html
+++ b/src/app/sync/sync.component.html
@@ -1,0 +1,4 @@
+<button (click)="getCode()">Generate Code</button>
+<p>{{code}}</p>
+<p>{{problem}}</p>
+<p>{{connect}}</p>

--- a/src/app/sync/sync.component.ts
+++ b/src/app/sync/sync.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { SocketService} from '../socket.service';
+
+@Component({
+  selector: 'app-sync',
+  templateUrl: './sync.component.html',
+  styleUrls: ['./sync.component.css']
+})
+export class SyncComponent implements OnInit, OnDestroy {
+
+  code = '';
+  problem = '';
+  connect = '';
+  problemObserver;
+  phoneObserver;
+
+  constructor(private socketService: SocketService) { }
+
+  ngOnInit() {
+    this.problemObserver = this.socketService
+      .getProblems()
+      .subscribe((data) => {
+        this.problem = String(data);
+      });
+    
+    this.phoneObserver = this.socketService
+      .getConnect()
+      .subscribe((data) => {
+        this.connect = String(data);
+      });
+  }
+
+  getCode() {
+    this.code = this.socketService.getCode();
+    this.socketService.sendMirrorCode(this.code);
+  }
+
+  ngOnDestroy() {
+    this.problemObserver.unsubscribe();
+    this.phoneObserver.unsubscribe();
+  }
+}


### PR DESCRIPTION
This adds the socket service and sync component.  Sync component looks like this:
![generatecode](https://user-images.githubusercontent.com/1727761/29467868-9f2c75f4-8407-11e7-9775-397c8c7d3331.png)
You can add it in the html with this:
```
<app-sync></app-sync>
```
The web url for the socket is in shared/stateInit.ts:
```
export const stateInit = {
  customer_present: false,
  product_available: false,
  paired_to_phone: false,
  photos:[],
  socket_url: 'ec2-54-221-218-6.compute-1.amazonaws.com:4000',
  }
```